### PR TITLE
leading . in file and directory names are kept after path clean

### DIFF
--- a/pkg/util/path/path.go
+++ b/pkg/util/path/path.go
@@ -72,5 +72,13 @@ func PathFromSource(dstFilepath, srcFilepath string) string {
 
 // ToRelative removes all ./, ../ etc prefixes from the string.
 func ToRelative(filepath string) string {
-	return strings.TrimLeft(path.Clean(filepath), "./")
+	cleaned := path.Clean(filepath)
+	if len(cleaned) == strings.Count(cleaned, ".") {
+		return ""
+	}
+	trimmed := strings.TrimLeft(cleaned, "./") // removed . and / chars from left
+	left := cleaned[:len(cleaned)-len(trimmed)]
+	// looking for . on the right side of the cut of left part
+	farLeft := strings.TrimRight(left, ".")
+	return cleaned[len(farLeft):]
 }

--- a/pkg/util/path/path_test.go
+++ b/pkg/util/path/path_test.go
@@ -70,11 +70,41 @@ func TestPathFromSource(t *testing.T) {
 	}
 
 	testPathFromSource("", "/long/path/to/source", "source")
+	testPathFromSource("", "/long/path/to/.source", ".source")
 	testPathFromSource("", "long/path/to/source", "source")
+	testPathFromSource("", "long/path/to/.source", ".source")
 	testPathFromSource("destination", "/long/path/to/source", "destination")
+	testPathFromSource(".destination", "/long/path/to/source", ".destination")
+	testPathFromSource("destination", "/long/path/to/.source", "destination")
+	testPathFromSource(".destination", "/long/path/to/.source", ".destination")
 	testPathFromSource("destination", "long/path/to/source", "destination")
-	testPathFromSource("long/path/to/destination", "long/path/to/source", "long/path/to/destination")
-	testPathFromSource("/long/path/to/destination", "long/path/to/source", "/long/path/to/destination")
+	testPathFromSource(".destination", "long/path/to/source", ".destination")
+	testPathFromSource("destination", "long/path/to/.source", "destination")
+	testPathFromSource(".destination", "long/path/to/.source", ".destination")
+	testPathFromSource("long/path/to/destination", "long/path/to/source",
+		"long/path/to/destination")
+	testPathFromSource(".long/path/to/destination", "long/path/to/source",
+		".long/path/to/destination")
+	testPathFromSource("long/path/to/destination", ".long/path/to/source",
+		"long/path/to/destination")
+	testPathFromSource(".long/path/to/destination", ".long/path/to/source",
+		".long/path/to/destination")
+	testPathFromSource("/long/path/to/destination", "long/path/to/source",
+		"/long/path/to/destination")
+	testPathFromSource("/.long/path/to/destination", "long/path/to/source",
+		"/.long/path/to/destination")
+	testPathFromSource("/long/path/to/destination", ".long/path/to/source",
+		"/long/path/to/destination")
+	testPathFromSource("/.long/path/to/destination", ".long/path/to/source",
+		"/.long/path/to/destination")
+	testPathFromSource("./long/path/to/destination", "long/path/to/source",
+		"./long/path/to/destination")
+	testPathFromSource("./.long/path/to/destination", "long/path/to/source",
+		"./.long/path/to/destination")
+	testPathFromSource("./long/path/to/destination", ".long/path/to/source",
+		"./long/path/to/destination")
+	testPathFromSource("./.long/path/to/destination", ".long/path/to/source",
+		"./.long/path/to/destination")
 }
 
 func TestToRelative(t *testing.T) {
@@ -88,12 +118,23 @@ func TestToRelative(t *testing.T) {
 
 	testToRelative("", "")
 	testToRelative("./../source", "source")
+	testToRelative("./../.source", ".source")
 	testToRelative("./../source/..", "")
 	testToRelative("./../source/../longer", "longer")
 	testToRelative("./../source/../longer/", "longer")
+	testToRelative("./../source/../.longer/", ".longer")
 	testToRelative("./../source/../longer/.", "longer")
+	testToRelative("./../source/../.longer/.", ".longer")
+	testToRelative("./../.source/../longer/.", "longer")
+	testToRelative("./../.source/../.longer/.", ".longer")
 	testToRelative("source", "source")
+	testToRelative(".source", ".source")
 	testToRelative("/source", "source")
+	testToRelative("./source", "source")
+	testToRelative("/.source", ".source")
 	testToRelative("long/path/to/source", "long/path/to/source")
+	testToRelative(".long/path/to/source", ".long/path/to/source")
 	testToRelative("/long/path/to/source", "long/path/to/source")
+	testToRelative("/.long/path/to/source", ".long/path/to/source")
+	testToRelative("./.long/path/to/source", ".long/path/to/source")
 }


### PR DESCRIPTION
hidden files and directories keep the leading `.` when pushing them to GCS
with tests