### PR TITLE
S3 support

### DIFF
--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -93,13 +93,26 @@ func isFileSrc(src string) (isF bool, ok bool) {
 
 // ParseURL parses object path from a signed URL.
 func ParseURL(u string) string {
-	re := regexp.MustCompile(`https:\/\/storage\.googleapis\.com\/[a-z0-9\-]+\/([^?]+)\?Expires=`)
-	parsed := re.FindStringSubmatch(u)
-	if len(parsed) < 2 {
-		log.Warn("ParseURL fails to parse", zap.String("url", u))
-		return ""
+	if strings.HasPrefix(u, "https://storage.googleapis.com") {
+		// GCS URLs follow the format 'https://storage.googleapis.com/<bucket-name>/<path>'
+		re := regexp.MustCompile(`https:\/\/storage\.googleapis\.com\/[a-z0-9\-]+\/([^?]+)\?Expires=`)
+		parsed := re.FindStringSubmatch(u)
+		if len(parsed) < 2 {
+			log.Warn("ParseURL fails to parse", zap.String("url", u))
+			return ""
+		}
+		return parsed[1]
+	} else {
+		// S3 URLs follow the format 'https://<bucket-name>.s3.<region>.amazonaws.com/<path>'
+		// Note: S3 URLs use the project id as a prefix, so we take that into account here as well
+		re := regexp.MustCompile(`https:\/\/(.+)\.s3\.(.+)\.amazonaws\.com\/[a-z0-9\-]+\/([^?]+)\?`)
+		parsed := re.FindStringSubmatch(u)
+		if len(parsed) < 4 {
+			log.Warn("ParseURL fails to parse", zap.String("url", u))
+			return ""
+		}
+		return parsed[3]
 	}
-	return parsed[1]
 }
 
 // SignedURL contains an url and its method type.
@@ -202,7 +215,15 @@ func UploadFile(u, filename string) (ok bool) {
 		return
 	}
 	defer f.Close()
-	return httputil.UploadReader(u, f)
+
+	fileInfo, err := f.Stat()
+	if err != nil {
+		log.Error("Failed to stat file for uploading", zap.String("filename", filename),
+			zap.Error(err))
+		return
+	}
+
+	return httputil.UploadReader(u, f, fileInfo.Size())
 }
 
 // PushPaths returns source and destination paths to push a file to Google Cloud Storage.

--- a/pkg/util/http/httputil_test.go
+++ b/pkg/util/http/httputil_test.go
@@ -38,8 +38,9 @@ func TestHTTPMethod(t *testing.T) {
 	u := "example.com"
 	content := "some content"
 	cr := strings.NewReader(content)
+	contentSize := int64(len(content))
 
-	check := func(method string, cr io.Reader, getBody bool) {
+	check := func(method string, cr io.Reader, contentSize int64, getBody bool) {
 		httpmock.ActivateNonDefault(httpClient)
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder(method, u,
@@ -54,7 +55,7 @@ func TestHTTPMethod(t *testing.T) {
 				return httpmock.NewStringResponse(200, ""), nil
 			},
 		)
-		ok, body := do(descr, u, method, cr, getBody)
+		ok, body := do(descr, u, method, cr, contentSize, getBody)
 		assert.True(t, ok, "should be fine but fails")
 		if getBody {
 			defer body.Close()
@@ -64,7 +65,7 @@ func TestHTTPMethod(t *testing.T) {
 		}
 	}
 
-	check(http.MethodGet, cr, true)
-	check(http.MethodPut, cr, false)
-	check(http.MethodDelete, nil, false)
+	check(http.MethodGet, cr, 0, true)
+	check(http.MethodPut, cr, contentSize, false)
+	check(http.MethodDelete, nil, 0, false)
 }


### PR DESCRIPTION
- Accept S3 signed URLs and parse them properly
- Set request `Content-Length` using the size of the file. If not set, S3 will return a `501 Not Implemented`