### PR TITLE
Use http.NoBody for empty files

### DIFF
--- a/pkg/util/http/httputil.go
+++ b/pkg/util/http/httputil.go
@@ -37,7 +37,15 @@ func formatIfErr(s int, descr, u string, r io.Reader) (ok bool) {
 // do does httpclient.Do with the given paramters. If getBody is true, the response body
 // is returned, and the responsability of closing it is transferred.
 func do(descr, u, method string, content io.Reader, size int64, getBody bool) (ok bool, body io.ReadCloser) {
-	req, err := http.NewRequest(method, u, content)
+	contentBody := content
+
+	// If the file has no bytes, we need to use http.NoBody
+	// See https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/request.go;l=920
+	if size == 0 {
+		contentBody = http.NoBody
+	}
+
+	req, err := http.NewRequest(method, u, contentBody)
 	if err != nil {
 		log.VerboseError("Failed to create new http request", zap.Error(err),
 			zap.String("while doing", descr), zap.String("url", u))

--- a/pkg/util/http/httputil.go
+++ b/pkg/util/http/httputil.go
@@ -41,7 +41,7 @@ func do(descr, u, method string, content io.Reader, size int64, getBody bool) (o
 
 	// If the file has no bytes, we need to use http.NoBody
 	// See https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/request.go;l=920
-	if size == 0 {
+	if method == http.MethodPut && size == 0 {
 		contentBody = http.NoBody
 	}
 


### PR DESCRIPTION
Comment from the [http.NewRequestWithContext()](https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/request.go;l=920) function:

```
// For client requests, Request.ContentLength of 0
// means either actually 0, or unknown. The only way
// to explicitly say that the ContentLength is zero is
// to set the Body to nil. But turns out too much code
// depends on NewRequest returning a non-nil Body,
// so we use a well-known ReadCloser variable instead
// and have the http package also treat that sentinel
// variable to mean explicitly zero.
```