### PR TITLE
Use stdin to push artifacts

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -24,7 +27,9 @@ while the rest of the semaphore process, or after it.`,
 func runPushForCategory(cmd *cobra.Command, args []string, category, catID string) (string, string) {
 	err := pathutil.InitPathID(category, catID)
 	errutil.Check(err)
-	src := args[0]
+
+	src, err := getSrc(cmd, args)
+	errutil.Check(err)
 
 	dst, err := cmd.Flags().GetString("destination")
 	errutil.Check(err)
@@ -134,4 +139,62 @@ Docs: https://docs.semaphoreci.com/essentials/artifacts/#artifact-retention-poli
 	PushJobCmd.Flags().StringP("job-id", "j", "", "set explicit job id")
 	PushWorkflowCmd.Flags().StringP("workflow-id", "w", "", "set explicit workflow id")
 	PushProjectCmd.Flags().StringP("project-id", "p", "", "set explicit project id")
+}
+
+func getSrc(cmd *cobra.Command, args []string) (string, error) {
+	if shouldUseStdin() {
+		log.Debug("Detected stdin, saving it to a temporary file...")
+		return saveStdinToTempFile()
+	}
+
+	return args[0], nil
+}
+
+func shouldUseStdin() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+func saveStdinToTempFile() (string, error) {
+	tmpFile, err := ioutil.TempFile("", "*")
+	if err != nil {
+		log.Error("Error creating temporary file to read stdin", zap.Error(err))
+		return "", err
+	}
+
+	r := bufio.NewReader(os.Stdin)
+	buf := make([]byte, 0, 8)
+
+	for {
+		nRead, err := r.Read(buf[:cap(buf)])
+		buf = buf[:nRead]
+
+		// nothing was read and no error was thrown, so just try again
+		if nRead == 0 && err == nil {
+			continue
+		}
+
+		// there's nothing more to read
+		if err == io.EOF {
+			break
+		}
+
+		// Something went wrong when reading
+		if err != nil {
+			log.Error("Error reading stdin", zap.Error(err))
+			return "", err
+		}
+
+		_, err = tmpFile.Write(buf)
+		if err != nil {
+			log.Error("Error writing to temp file", zap.Error(err))
+			return "", err
+		}
+	}
+
+	return tmpFile.Name(), nil
 }


### PR DESCRIPTION
## Push using stdin

```
» docker image save alpine/helm | gzip | ./artifact push job - -d alpine-image -v -f
...
2022/05/17 18:46:36 Detected stdin, saving it to a temporary file...
2022-05-17T18:46:36.952-0300	DEBUG	log/log.go:85	Detected stdin, saving it to a temporary file...
2022/05/17 18:46:44 PushPaths
2022-05-17T18:46:44.243-0300	DEBUG	log/log.go:85	PushPaths	{"input destination": "alpine-image", "input source": "/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/982060311", "output destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/alpine-image", "output source": "/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/982060311"}
2022/05/17 18:46:44 pushing...
2022-05-17T18:46:44.255-0300	DEBUG	log/log.go:85	pushing...	{"source": "/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/982060311", "destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/alpine-image", "force": true}
2022/05/17 18:46:44 the source seems to be a file
2022-05-17T18:46:44.255-0300	DEBUG	log/log.go:85	the source seems to be a file	{"source": "/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/982060311"}
2022/05/17 18:46:44 Uploading...
2022-05-17T18:46:44.620-0300	DEBUG	log/log.go:85	Uploading...	{"source": "/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/982060311", "destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/alpine-image"}
2022/05/17 18:46:48 successful push for current job
2022-05-17T18:46:48.091-0300	INFO	log/log.go:78	successful push for current job	{"source": "/var/folders/qz/fys7r29s4cz9l_rn8zsmssz80000gn/T/982060311", "destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/alpine-image"}
```

- In the example above, `-` is used for the file name because that's a common practice, but it doesn't really matter. If there's something being piped into the artifact CLI, we read that and ignore whatever is passed as a parameter.

## Push using regular file

```
» ./artifact push job README.md -v
...
2022-05-17T18:49:49.837-0300	DEBUG	log/log.go:85	PushPaths	{"input destination": "", "input source": "README.md", "output destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/README.md", "output source": "README.md"}
2022/05/17 18:49:49 pushing...
2022-05-17T18:49:49.837-0300	DEBUG	log/log.go:85	pushing...	{"source": "README.md", "destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/README.md", "force": false}
2022/05/17 18:49:49 the source seems to be a file
2022-05-17T18:49:49.837-0300	DEBUG	log/log.go:85	the source seems to be a file	{"source": "README.md"}
2022/05/17 18:49:50 Uploading...
2022-05-17T18:49:50.588-0300	DEBUG	log/log.go:85	Uploading...	{"source": "README.md", "destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/README.md"}
2022/05/17 18:49:50 successful push for current job
2022-05-17T18:49:50.839-0300	INFO	log/log.go:78	successful push for current job	{"source": "README.md", "destination": "artifacts/jobs/9eb052ad-a4c5-4570-91e8-94539d7320b6/README.md"}
```