### PR TITLE
Determine if input comes from stdin from arguments

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -184,7 +184,7 @@ func init() {
 func getSrc(args []string) (string, error) {
 	input := args[0]
 	if shouldUseStdin(input) {
-		log.Debug("Detected stdin, saving it to a temporary file...")
+		log.Debug("Detected stdin, saving it to a temporary file...\n")
 		return saveStdinToTempFile()
 	}
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -188,7 +188,7 @@ func getSrc(args []string) (string, error) {
 		return saveStdinToTempFile()
 	}
 
-	return args[0], nil
+	return input, nil
 }
 
 func shouldUseStdin(input string) bool {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -39,7 +39,7 @@ func runPushForCategory(cmd *cobra.Command, args []string, resolver *files.PathR
 	hubClient, err := hub.NewClient()
 	errutil.Check(err)
 
-	localSource, err := getSrc(cmd, args)
+	localSource, err := getSrc(args)
 	errutil.Check(err)
 
 	destinationOverride, err := cmd.Flags().GetString("destination")
@@ -181,8 +181,9 @@ func init() {
 	pushCmd.AddCommand(NewPushProjectCmd())
 }
 
-func getSrc(cmd *cobra.Command, args []string) (string, error) {
-	if shouldUseStdin() {
+func getSrc(args []string) (string, error) {
+	input := args[0]
+	if shouldUseStdin(input) {
 		log.Debug("Detected stdin, saving it to a temporary file...")
 		return saveStdinToTempFile()
 	}
@@ -190,13 +191,12 @@ func getSrc(cmd *cobra.Command, args []string) (string, error) {
 	return args[0], nil
 }
 
-func shouldUseStdin() bool {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false
+func shouldUseStdin(input string) bool {
+	if input == "-" || input == "/dev/stdin" {
+		return true
 	}
 
-	return (stat.Mode() & os.ModeCharDevice) == 0
+	return false
 }
 
 func saveStdinToTempFile() (string, error) {

--- a/pkg/api/signed_url.go
+++ b/pkg/api/signed_url.go
@@ -76,7 +76,7 @@ func (u *SignedURL) put(client *http.Client, artifact *Artifact) error {
 	// If the file has no bytes, we need to use http.NoBody
 	// See https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/request.go;l=920
 	if fileInfo.Size() == 0 {
-		log.Debugf("'%s' is empty.", artifact.LocalPath)
+		log.Debugf("'%s' is empty.\n", artifact.LocalPath)
 		contentBody = http.NoBody
 	}
 


### PR DESCRIPTION
Related to https://github.com/renderedtext/tasks/issues/3084.

Relying on the mode of `os.Stdin` to determine if we should use standard input or a file to upload can lead to issues when using the CLI with make's `--jobs` parameter, since the [POSIX jobserver implementation](https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html#POSIX-Jobserver) uses a pipe.

Here, we take a simpler approach to determine if we should read from standard input or from a file:
- if the input parameter is `-` or `/dev/stdin`, we read from standard input
- if the input parameter is anything else, we assume it is a file and will read from it