### PR TITLE
fix: update release configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ builds:
       - 386
       - amd64
       - arm
-      - arm64
 
 archives:
   - id: non-windows-archive

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -14,7 +14,7 @@ blocks:
         - name: github-release-bot-artifact
       prologue:
         commands:
-          - sem-version go 1.12
+          - sem-version go 1.16
           - "export GOPATH=~/go"
           - "export PATH=~/go/bin:$PATH"
           - checkout


### PR DESCRIPTION
- Use go v1.16 on release promotion
- Remove `windows/arm64` from desired binaries