### PR TITLE
Vm/dont do needles retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.vscode/*
+
 artifact
 junit-report.xml

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -14,6 +15,9 @@ func RetryWithConstantWait(task string, maxAttempts int, wait time.Duration, f f
 			return nil
 		}
 
+		if !strings.Contains(err.Error(), "500") {
+			return err
+		}
 		if attempt >= maxAttempts {
 			return fmt.Errorf("[%s] failed after [%d] attempts - giving up: %v", task, attempt, err)
 		}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -22,7 +22,7 @@ func Test__GivesUpAfterMaxRetries(t *testing.T) {
 	attempts := 0
 	err := RetryWithConstantWait("test", 5, 100*time.Millisecond, func() error {
 		attempts++
-		return errors.New("bad error")
+		return errors.New("bad error 500")
 	})
 	assert.Equal(t, attempts, 5)
 	assert.NotNil(t, err)


### PR DESCRIPTION
Dont retry sending requests to artifacthub if token isn't correct or artifact doesn't exist