### PR TITLE
fix: S3 empty file upload

### DIFF
--- a/pkg/api/signed_url.go
+++ b/pkg/api/signed_url.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -80,7 +79,7 @@ func (u *SignedURL) put(client *retryablehttp.Client, artifact *Artifact) error 
 	// See https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/request.go;l=920
 	if fileInfo.Size() == 0 {
 		log.Debugf("'%s' is empty.\n", artifact.LocalPath)
-		contentBody = http.NoBody
+		contentBody = nil
 	}
 
 	log.Debugf("PUT '%s'...\n", u.URL)

--- a/test/support/storage.go
+++ b/test/support/storage.go
@@ -116,6 +116,15 @@ func (m *StorageMockServer) handleGETRequest(w http.ResponseWriter, r *http.Requ
 }
 
 func (m *StorageMockServer) handlePUTRequest(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("[STORAGE MOCK] Headers: %v\n", r.Header)
+
+	// S3 returns 501 if the Content-Length header to be set.
+	contentLength := r.Header.Get("Content-Length")
+	if contentLength == "" {
+		fmt.Printf("[STORAGE MOCK] [ERROR] No Content-Length HTTP header set.")
+		w.WriteHeader(501)
+	}
+
 	object := r.URL.Path[1:]
 	err := m.addFile(object, r.Body)
 	if err != nil {


### PR DESCRIPTION
The retryablehttp client does not set the HTTP Content-Length header to 0 when using http.NoBody. And that causes problems with S3 when uploading empty files. We should use nil instead.